### PR TITLE
Require cmake to check for armadillo library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ include(GrVersion)
 
 include(GrPlatform) #define LIB_SUFFIX
 
-find_package(Armadillo)
+find_package(Armadillo REQUIRED)
 
 if(NOT CMAKE_MODULES_DIR)
   set(CMAKE_MODULES_DIR lib${LIB_SUFFIX}/cmake)


### PR DESCRIPTION
gr-equalizers will not compile and install without the armadillo library (apt-get install libarmadillo-dev). Require cmake to check for armadillo library.